### PR TITLE
質問編集機能の実装

### DIFF
--- a/WebContent/WEB-INF/JSP/QandAConfirm.jsp
+++ b/WebContent/WEB-INF/JSP/QandAConfirm.jsp
@@ -67,7 +67,10 @@
               <p>編集・削除キー</p>
             </div>
             <div class="question-element edit-delete-execute">
-              <p class="registered-key"><input type="text" class="user-input" placeholder="数字４桁以上"></p>
+              <form name="editForm" method="POST" action="edit">
+                <p class="registered-key"><input type="text" name="editDeleteKey" class="user-input" placeholder="数字４桁以上"></p>
+                <input name="question_id" type="hidden" value="${question.questionId}">
+              </form>
               <button id="edit-btn" class="edit-execute action-btn">編集する</button>
               <button id="delete-btn" class="delete-execute action-btn">削除する</button>
             </div>
@@ -137,7 +140,7 @@
         <div class="close-btn" id="edit-popup-close-btn"><i class="fas fa-times"></i></div>
         <div class="request-confirmation">
           <p>編集画面に移ります。よろしいですか。</p>
-          <a class="request-confirmed" href="edit">編集する</a>
+          <button id="edit-confirmed-btn" class="request-confirmed">編集する</button>
           <button class="request-canceled" id="edit-cancel-btn">キャンセル</button>
         </div>
       </div>
@@ -148,7 +151,7 @@
         <div class="close-btn" id="delete-popup-close-btn"><i class="fas fa-times"></i></div>
         <div class="request-confirmation">
           <p>削除します。よろしいですか。</p>
-          <a class="request-confirmed" href="delete">削除</a>
+          <button class="request-confirmed">削除</button>
           <button class="request-canceled" id="delete-cancel-btn">キャンセル</button>
         </div>
       </div>

--- a/WebContent/WEB-INF/JSP/QandAConfirm.jsp
+++ b/WebContent/WEB-INF/JSP/QandAConfirm.jsp
@@ -2,8 +2,8 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ page import="model.Question, model.Answer, java.util.Date, java.util.List" %>
 <% String errorMsgAnswer = (String) request.getAttribute("errorMsgAnswer"); %>
-<% final String errorId = (String) request.getParameter("errorId"); %>
-<% final String errorMsgKeyUnmatched = "「編集・削除キーが一致しません。」"; %>
+<% String errorId = (String) request.getParameter("errorId"); %>
+<% String errorMsgKeyUnmatched = "「編集・削除キーが一致しません。」"; %>
 <% String answererName = (String) request.getAttribute("answererName"); %>
 <% String answerContent = (String) request.getAttribute("answerContent"); %>
 <%

--- a/WebContent/WEB-INF/JSP/QandAConfirm.jsp
+++ b/WebContent/WEB-INF/JSP/QandAConfirm.jsp
@@ -2,6 +2,8 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ page import="model.Question, model.Answer, java.util.Date, java.util.List" %>
 <% String errorMsgAnswer = (String) request.getAttribute("errorMsgAnswer"); %>
+<% final String errorId = (String) request.getParameter("errorId"); %>
+<% final String errorMsgKeyUnmatched = "「編集・削除キーが一致しません。」"; %>
 <% String answererName = (String) request.getAttribute("answererName"); %>
 <% String answerContent = (String) request.getAttribute("answerContent"); %>
 <%
@@ -34,6 +36,12 @@
   <main>
     <section class="page-subtitle-container">
       <h1 class="page-subtitle">${question.title}</h1>
+      <!-- 回答登録エラー発生時の処理 -->
+      <% if (errorId != null && (errorId.equals("1") || errorId.equals("2"))) { %>
+          <div class="error-msg-key-unmatched">
+            <p><%= errorMsgKeyUnmatched %></p>
+          </div>
+      <% } %>
     </section>
     <section class="main-outer-wrapper-confirm">
       <div class="main-inner-wrapper-confirm">
@@ -68,7 +76,7 @@
             </div>
             <div class="question-element edit-delete-execute">
               <form name="editForm" method="POST" action="edit">
-                <p class="registered-key"><input type="text" name="editDeleteKey" class="user-input" placeholder="数字４桁以上"></p>
+                <p class="registered-key"><input type="text" name="edit-delete-key" class="user-input" placeholder="数字４桁以上"></p>
                 <input name="question_id" type="hidden" value="${question.questionId}">
               </form>
               <button id="edit-btn" class="edit-execute action-btn">編集する</button>

--- a/WebContent/WEB-INF/JSP/QandAConfirm.jsp
+++ b/WebContent/WEB-INF/JSP/QandAConfirm.jsp
@@ -3,7 +3,7 @@
 <%@ page import="model.Question, model.Answer, java.util.Date, java.util.List" %>
 <% String errorMsgAnswer = (String) request.getAttribute("errorMsgAnswer"); %>
 <% String errorId = (String) request.getParameter("errorId"); %>
-<% String errorMsgKeyUnmatched = "「編集・削除キーが一致しません。」"; %>
+<% String errorMsgKeyUnmatched = "「編集・削除キー」が一致しません。"; %>
 <% String answererName = (String) request.getAttribute("answererName"); %>
 <% String answerContent = (String) request.getAttribute("answerContent"); %>
 <%
@@ -75,8 +75,8 @@
               <p>編集・削除キー</p>
             </div>
             <div class="question-element edit-delete-execute">
-              <form name="editForm" method="POST" action="edit">
-                <p class="registered-key"><input type="text" name="edit-delete-key" class="user-input" placeholder="数字４桁以上"></p>
+              <form name="editDeleteForm" method="POST" action="edit">
+                <p class="registered-key"><input type="text" name="edit-delete-key" class="user-input" placeholder="例）1234, abc"></p>
                 <input name="question_id" type="hidden" value="${question.questionId}">
               </form>
               <button id="edit-btn" class="edit-execute action-btn">編集する</button>

--- a/WebContent/WEB-INF/JSP/QandAEdit.jsp
+++ b/WebContent/WEB-INF/JSP/QandAEdit.jsp
@@ -35,7 +35,7 @@
               <p>名前（ハンドルネーム）</p>
             </div>
             <div class="question-element">
-              <p class="questioner-name"><input name="handle-name" type="text" class="user-input" placeholder="名前（ハンドルネーム）" value="${question.handleName}"></p>
+              <p class="questioner-name"><input name="questioner-name" type="text" class="user-input" placeholder="名前（ハンドルネーム）" value="${question.handleName}"></p>
             </div>
           </div>
           <div class="question-element-row">
@@ -60,13 +60,13 @@
             </div>
             <div class="question-element urgency-levels-user-input">
               <p class="urgency">
-                <label for="urgent"><input type="radio" name="urgency" value="urgent" id="urgent" <% if (urgency == 1) { %> checked="checked" <% } %>>急いでいます</label>
+                <label for="urgent"><input type="radio" name="urgency" value=1 id="urgent" <% if (urgency == 1) { %> checked="checked" <% } %>>急いでいます</label>
               </p>
               <p class="urgency">
-                <label for="advisable"><input type="radio" name="urgency" value="advisable" id="advisable" <% if (urgency == 2) { %> checked="checked" <% } %>>困っています</label>
+                <label for="advisable"><input type="radio" name="urgency" value=2 id="advisable" <% if (urgency == 2) { %> checked="checked" <% } %>>困っています</label>
               </p>
               <p class="urgency">
-                <label for="anytime"><input type="radio" name="urgency" value="anytime" id="anytime" <% if (urgency == 3) { %> checked="checked" <% } %>>いつでも</label>
+                <label for="anytime"><input type="radio" name="urgency" value=3 id="anytime" <% if (urgency == 3) { %> checked="checked" <% } %>>いつでも</label>
               </p>
             </div>
           </div>
@@ -79,7 +79,7 @@
             </div>
           </div>
         </div>
-        <input type="hidden" name="question_id" value="${question.questionId}">
+        <input type="hidden" name="questionId" value="${question.questionId}">
       </form>
       <div class="register-cancel-execute">
         <button class="register-btn action-btn" id="js-trigger">更新</button>

--- a/WebContent/WEB-INF/JSP/QandAEdit.jsp
+++ b/WebContent/WEB-INF/JSP/QandAEdit.jsp
@@ -1,6 +1,7 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ page import="model.Question" %>
 <% Question question = (Question) request.getAttribute("question"); %>
+<% String errorMsg = (String) request.getAttribute("errorMsg"); %>
 <% int urgency = (int) question.getUrgency(); %>
 <!DOCTYPE html>
 <html lang="ja">
@@ -26,6 +27,11 @@
   <main>
     <section class="page-subtitle-container">
       <h1 class="page-subtitle">質問編集</h1>
+      <% if (errorMsg != null) { %>
+        <div class="error-msg">
+          <p><%= errorMsg %></p>
+        </div>
+      <% } %>
     </section>
     <section class="main-outer-wrapper-common">
       <form name="updatedForm" action="editComplete" method="POST">
@@ -75,7 +81,7 @@
               <p>編集・削除キー</p>
             </div>
             <div class="register-cancel">
-              <p class="register-cancel-key"><input name="edit-delete-key" type="text" class="user-input" placeholder="数字4桁以上"></p>
+              <p class="register-cancel-key"><input name="edit-delete-key" type="text" class="user-input" placeholder="例）1234, abc"></p>
             </div>
           </div>
         </div>

--- a/WebContent/WEB-INF/JSP/QandAEdit.jsp
+++ b/WebContent/WEB-INF/JSP/QandAEdit.jsp
@@ -1,4 +1,7 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ page import="model.Question" %>
+<% Question question = (Question) request.getAttribute("question"); %>
+<% int urgency = (int) question.getUrgency(); %>
 <!DOCTYPE html>
 <html lang="ja">
 
@@ -10,6 +13,8 @@
   <link rel="stylesheet" href="${pageContext.request.contextPath}/css/reset.css">
   <link rel="stylesheet" href="${pageContext.request.contextPath}/css/fontawesome.css">
   <link rel="stylesheet" href="${pageContext.request.contextPath}/css/QAndACommon.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="./apple-touch-icon-180x180.png">
+  <link rel="icon" type="image/x-icon" href="./favicon.ico">
 </head>
 
 <body>
@@ -23,59 +28,62 @@
       <h1 class="page-subtitle">質問編集</h1>
     </section>
     <section class="main-outer-wrapper-common">
-      <div class="main-inner-wrapper-common">
-        <div class="question-element-row">
-          <div class="question-element-title">
-            <p>名前（ハンドルネーム）</p>
+      <form name="updatedForm" action="editComplete" method="POST">
+        <div class="main-inner-wrapper-common">
+          <div class="question-element-row">
+            <div class="question-element-title">
+              <p>名前（ハンドルネーム）</p>
+            </div>
+            <div class="question-element">
+              <p class="questioner-name"><input name="handle-name" type="text" class="user-input" placeholder="名前（ハンドルネーム）" value="${question.handleName}"></p>
+            </div>
           </div>
-          <div class="question-element">
-            <p class="questioner-name"><input type="text" class="user-input" placeholder="名前（ハンドルネーム）"></p>
+          <div class="question-element-row">
+            <div class="question-element-title">
+              <p>タイトル</p>
+            </div>
+            <div class="question-element">
+              <p class="question-title"><input name="question-title" type="text" class="user-input" placeholder="タイトル" value="${question.title}"></p>
+            </div>
+          </div>
+          <div class="question-element-row">
+            <div class="question-element-title">
+              <p>内容</p>
+            </div>
+            <div class="question-element">
+              <textarea name="question-content" class="question-content" cols="30" rows="15" placeholder="内容">${question.contents}</textarea>
+            </div>
+          </div>
+          <div class="question-element-row urgency-levels">
+            <div class="question-element-title">
+              <p>緊急度</p>
+            </div>
+            <div class="question-element urgency-levels-user-input">
+              <p class="urgency">
+                <label for="urgent"><input type="radio" name="urgency" value="urgent" id="urgent" <% if (urgency == 1) { %> checked="checked" <% } %>>急いでいます</label>
+              </p>
+              <p class="urgency">
+                <label for="advisable"><input type="radio" name="urgency" value="advisable" id="advisable" <% if (urgency == 2) { %> checked="checked" <% } %>>困っています</label>
+              </p>
+              <p class="urgency">
+                <label for="anytime"><input type="radio" name="urgency" value="anytime" id="anytime" <% if (urgency == 3) { %> checked="checked" <% } %>>いつでも</label>
+              </p>
+            </div>
+          </div>
+          <div class="question-element-row">
+            <div class="question-element-title">
+              <p>編集・削除キー</p>
+            </div>
+            <div class="register-cancel">
+              <p class="register-cancel-key"><input name="edit-delete-key" type="text" class="user-input" placeholder="数字4桁以上"></p>
+            </div>
           </div>
         </div>
-        <div class="question-element-row">
-          <div class="question-element-title">
-            <p>タイトル</p>
-          </div>
-          <div class="question-element">
-            <p class="question-title"><input type="text" class="user-input" placeholder="タイトル"></p>
-          </div>
-        </div>
-        <div class="question-element-row">
-          <div class="question-element-title">
-            <p>内容</p>
-          </div>
-          <div class="question-element">
-            <textarea class="question-content" cols="30" rows="15" placeholder="内容"></textarea>
-          </div>
-        </div>
-        <div class="question-element-row urgency-levels">
-          <div class="question-element-title">
-            <p>緊急度</p>
-          </div>
-          <div class="question-element urgency-levels-user-input">
-            <p class="urgency">
-              <label for="urgent"><input type="radio" name="urgency" value="urgent" id="urgent">急いでいます</label>
-            </p>
-            <p class="urgency">
-              <label for="advisable"><input type="radio" name="urgency" value="advisable" id="advisable">困っています</label>
-            </p>
-            <p class="urgency">
-              <label for="anytime"><input type="radio" name="urgency" value="anytime" id="anytime">いつでも</label>
-            </p>
-          </div>
-        </div>
-        <div class="question-element-row">
-          <div class="question-element-title">
-            <p>編集・削除キー</p>
-          </div>
-          <div class="register-cancel">
-            <p class="register-cancel-key"><input type="text" class="user-input" placeholder="数字4桁以上"></p>
-          </div>
-        </div>
-      </div>
+        <input type="hidden" name="question_id" value="${question.questionId}">
+      </form>
       <div class="register-cancel-execute">
         <button class="register-btn action-btn" id="js-trigger">更新</button>
-        <p class="cancel-btn"><a class="action-btn" href="list">キャンセル</a></p>
+        <p class="cancel-btn"><a class="action-btn" href="confirm?questionId=${question.questionId}">キャンセル</a></p>
       </div>
     </section>
     <div class="popup" id="js-popup">
@@ -83,7 +91,7 @@
         <div class="close-btn" id="js-close-btn"><i class="fas fa-times"></i></div>
         <div class="request-confirmation">
           <p>更新します。よろしいですか。</p>
-          <a class="request-confirmed" href="editComplete">更新</a>
+          <button class="request-confirmed" id="update-confirmed-btn">更新</button>
           <button class="request-canceled" id="request-canceled">キャンセル</button>
         </div>
       </div>

--- a/WebContent/css/QAndAConfirm.css
+++ b/WebContent/css/QAndAConfirm.css
@@ -6,6 +6,10 @@
 .question-element-wrapper-confirm {
   margin-bottom: 76.6px;
 }
+.error-msg-key-unmatched {
+  color: #F70B0B;
+  font-size: 20px;
+}
 .urgency-levels-confirmed {
   align-items: baseline;
 }
@@ -94,7 +98,7 @@ p.your-answer {
 .your-answer-element > textarea {
   padding: 9px 13px;
 }
-.your-answer-element > p, 
+.your-answer-element > p,
 .your-answer-element > textarea,
 .register-cancel-execute > p {
   border: 1px solid #ccc;

--- a/WebContent/css/QAndAConfirm.css
+++ b/WebContent/css/QAndAConfirm.css
@@ -108,7 +108,6 @@ p.your-answer {
   width: 100%;
 }
 .question-content {
-  letter-spacing: 2px;
   line-height: 1.5;
 }
 .send-answer-btn {

--- a/WebContent/js/popup.js
+++ b/WebContent/js/popup.js
@@ -10,6 +10,7 @@ function popup() {
   const showBtn = document.getElementById('js-trigger');
 
   const questionRegistryBtn = document.getElementById('question-registry-btn');
+  const updateConfirmedBtn = document.getElementById('update-confirmed-btn');
 
   closePopUp(blackBg);
   closePopUp(closeBtn);
@@ -21,13 +22,19 @@ function popup() {
       popup.classList.toggle('is-show');
     });
   }
-
   sendQuestionForm(questionRegistryBtn);
   function sendQuestionForm(elem) {
     if (!elem) return;
     elem.addEventListener('click', function () {
       document.questionForm.submit();
     })
+  }
+  sendUpdatedForm(updateConfirmedBtn);
+  function sendUpdatedForm(elem) {
+    if (!elem) return;
+    elem.addEventListener('click', function () {
+      document.updatedForm.submit();
+    });
   }
 }
 popup();

--- a/WebContent/js/popup_confirm.js
+++ b/WebContent/js/popup_confirm.js
@@ -24,7 +24,7 @@ function editPopup() {
   function sendEditForm(elem) {
     if (!elem) return;
     elem.addEventListener('click', function () {
-      document.editForm.submit();
+      document.editDeleteForm.submit();
     });
   }
 }

--- a/WebContent/js/popup_confirm.js
+++ b/WebContent/js/popup_confirm.js
@@ -8,6 +8,8 @@ function editPopup() {
   const cancelBtn = document.getElementById('edit-cancel-btn')
   const showBtn = document.getElementById('edit-btn');
 
+  const editConfirmedBtn = document.getElementById('edit-confirmed-btn');
+
   closePopUp(blackBg);
   closePopUp(closeBtn);
   closePopUp(cancelBtn);
@@ -16,6 +18,13 @@ function editPopup() {
     if (!elem) return;
     elem.addEventListener('click', function () {
       popup.classList.toggle('is-show');
+    });
+  }
+  sendEditForm(editConfirmedBtn);
+  function sendEditForm(elem) {
+    if (!elem) return;
+    elem.addEventListener('click', function () {
+      document.editForm.submit();
     });
   }
 }
@@ -69,7 +78,7 @@ function sendAnswerPopup() {
     if (!elem) return;
     elem.addEventListener('click', function () {
       document.answerForm.submit();
-    })
+    });
   }
 }
 

--- a/src/dao/QuestionsDAO.java
+++ b/src/dao/QuestionsDAO.java
@@ -151,6 +151,57 @@ public class QuestionsDAO {
 			return question;
 		}
 
+		// 質問詳細情報の取得
+		public Question questionEdit(int questionId) throws SQLException, ClassNotFoundException {
+			Connection conn = null;
+			Question question = new Question();
+
+			try {
+				// JDBCドライバを読み込む
+				try {
+					Class.forName(DRIVER_NAME);
+				} catch (ClassNotFoundException e) {
+					e.printStackTrace();
+				}
+				// DBへ接続
+				conn = DriverManager.getConnection(URL, USER, PASSWORD);
+				// SQL文を用意
+				String sql = "SELECT question_id, handle_name, title, contents, urgency, edit_delete_key FROM questions WHERE question_id = ?";
+				PreparedStatement pstmt = conn.prepareStatement(sql);
+				pstmt.setInt(1, questionId);
+
+				ResultSet rs = pstmt.executeQuery();
+				while (rs.next()) {
+					int questionSeqId = rs.getInt("question_id");
+					String handleName = rs.getString("handle_name");
+					String title = rs.getString("title");
+					String contents = rs.getString("contents");
+					int urgency = rs.getInt("urgency");
+					String editDeleteKey = rs.getString("edit_delete_key");
+					question.setQuestionId(questionSeqId);
+					question.setHandleName(handleName);
+					question.setTitle(title);
+					question.setContents(contents);
+					question.setUrgency(urgency);
+					question.setEditDeleteKey(editDeleteKey);
+				}
+				} catch (SQLException e) {
+					e.printStackTrace();
+					return null;
+				} finally {
+				// DBから切断
+				if (conn != null) {
+					try {
+						conn.close();
+					} catch (SQLException e) {
+						e.printStackTrace();
+						return null;
+					}
+				}
+			}
+			return question;
+		}
+
     // 質問登録の処理
     public boolean create(Question question) {
     	Connection conn = null;  // コネクションオブジェクト

--- a/src/dao/QuestionsDAO.java
+++ b/src/dao/QuestionsDAO.java
@@ -245,4 +245,48 @@ public class QuestionsDAO {
     	}
     	return false;
     }
+		// 質問登録の処理
+    public boolean update(Question question) throws SQLException, ClassNotFoundException {
+    	Connection conn = null;  // コネクションオブジェクト
+    	try {
+			// JDBCドライバを読み込む
+			try {
+				Class.forName(DRIVER_NAME);
+			} catch (ClassNotFoundException e) {
+				// TODO 自動生成された catch ブロック
+				e.printStackTrace();
+			}
+    		// DBへ接続
+    		conn = DriverManager.getConnection(URL, USER, PASSWORD);
+
+    		// INSERT文を用意
+    		String sql = "UPDATE questions SET handle_name=?, title=?, contents=?, urgency=?, edit_delete_key=?, update_timestamp=NOW() WHERE question_id=?";
+    		PreparedStatement pstmt = conn.prepareStatement(sql);
+
+    		pstmt.setString(1, question.getHandleName());
+    		pstmt.setString(2, question.getTitle());
+    		pstmt.setString(3, question.getContents());
+    		pstmt.setInt(4, question.getUrgency());
+    		pstmt.setString(5, question.getEditDeleteKey());
+    		pstmt.setInt(6, question.getQuestionId());
+
+    		int result = pstmt.executeUpdate();
+    		if (result != 1) {
+    			return false;
+    		}
+    	} catch (SQLException e) {
+    		e.printStackTrace();
+    		return false;
+    	} finally {
+    		// DB切断
+    		if (conn != null) {
+    			try {
+    				conn.close();
+    			} catch (SQLException e) {
+    				e.printStackTrace();
+    			}
+    		}
+    	}
+    	return false;
+    }
 }

--- a/src/edit.java
+++ b/src/edit.java
@@ -9,6 +9,9 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import model.Question;
+import model.VerifyKeyGetQuestionLogic;
+
 /**
  * Servlet implementation class edit
  * @author Ryunosuke Fukuda
@@ -39,8 +42,34 @@ public class edit extends HttpServlet {
 	 * @see HttpServlet#doPost(HttpServletRequest request, HttpServletResponse response)
 	 */
 	protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-		// TODO Auto-generated method stub
-		doGet(request, response);
-	}
+		request.setCharacterEncoding("UTF-8");
+		// フォーム送信によってpostされた値を変数に格納
+		int questionId = Integer.parseInt(request.getParameter("question_id"));
+		String editDeleteKey = request.getParameter("edit-delete-key");
 
+		if (questionId > 0 && editDeleteKey != "") {
+			VerifyKeyGetQuestionLogic VerifyKeyGetQuestionLogic = new VerifyKeyGetQuestionLogic();
+			try {
+				Question question = VerifyKeyGetQuestionLogic.execute(questionId);
+				String verifyKey = question.getEditDeleteKey();
+
+				if (editDeleteKey.equals(verifyKey)) {
+					request.setAttribute("question", question);
+					RequestDispatcher dispatcher = request.getRequestDispatcher("/WEB-INF/JSP/QandAEdit.jsp");
+
+					System.out.println(question);
+					dispatcher.forward(request, response);
+				} else {
+					response.sendRedirect("/QandASystem/confirm?questionId=" + questionId + "&errorId=" + 1);
+				}
+			} catch (Exception e) {
+				// 予期せぬエラーをキャッチした時も同様に、エラー画面に遷移させ処理を終わらせる
+				RequestDispatcher dispatcher = request.getRequestDispatcher("/WEB-INF/JSP/QandAError.jsp");
+				dispatcher.forward(request, response);
+				return;
+			}
+		} else {
+			response.sendRedirect("/QandASystem/confirm?questionId=" + questionId + "&errorId=" + 2);
+		}
+	}
 }

--- a/src/edit.java
+++ b/src/edit.java
@@ -34,8 +34,15 @@ public class edit extends HttpServlet {
 	 * フォワード先（/WEB-INF/JSP/QandAEdit.jsp）
 	 */
 	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-		// 編集画面に直接アクセスされた際は、質問一覧画面に強制リダイレクトさせる
-		response.sendRedirect("/QandASystem/list");
+		RequestDispatcher dispatcher = request.getRequestDispatcher("/WEB-INF/JSP/QandAEdit.jsp");
+		Question question = (Question) request.getAttribute("question");
+		if (question != null) {
+			dispatcher.forward(request, response);
+		} else {
+			System.out.println("/editへの直接アクセスは受け付けない。");
+			response.sendRedirect("list");
+			return;
+		}
 	}
 
 	/**

--- a/src/edit.java
+++ b/src/edit.java
@@ -1,6 +1,7 @@
 
 
 import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
 
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletException;
@@ -11,6 +12,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import model.Question;
 import model.VerifyKeyGetQuestionLogic;
+import sandbox.Hashing;
 
 /**
  * Servlet implementation class edit
@@ -39,7 +41,6 @@ public class edit extends HttpServlet {
 		if (question != null) {
 			dispatcher.forward(request, response);
 		} else {
-			System.out.println("/editへの直接アクセスは受け付けない。");
 			response.sendRedirect("list");
 			return;
 		}
@@ -53,7 +54,6 @@ public class edit extends HttpServlet {
 		// フォーム送信によってpostされた値を変数に格納
 		int questionId = Integer.parseInt(request.getParameter("question_id"));
 		String editDeleteKey = request.getParameter("edit-delete-key");
-
 		// 「編集・削除キー」がNULLではない場合に限り、DBへの問い合わせを行う
 		if (questionId > 0 && editDeleteKey != "") {
 			VerifyKeyGetQuestionLogic VerifyKeyGetQuestionLogic = new VerifyKeyGetQuestionLogic();
@@ -62,6 +62,13 @@ public class edit extends HttpServlet {
 				Question question = VerifyKeyGetQuestionLogic.execute(questionId);
 				// 取得した質問情報から「編集・削除キー」を変数に格納する
 				String verifyKey = question.getEditDeleteKey();
+				try {
+					Hashing Hashing = new Hashing();
+					editDeleteKey = Hashing.hash(editDeleteKey);
+				} catch (NoSuchAlgorithmException e) {
+					e.printStackTrace();
+		    	return;
+				}
 				// POSTされた「編集・削除キー」がDBの値と一致した場合は、取得した質問情報をJSPに渡し、編集画面に遷移する
 				if (editDeleteKey.equals(verifyKey)) {
 					request.setAttribute("question", question);

--- a/src/edit.java
+++ b/src/edit.java
@@ -34,8 +34,8 @@ public class edit extends HttpServlet {
 	 * フォワード先（/WEB-INF/JSP/QandAEdit.jsp）
 	 */
 	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-		RequestDispatcher dispatcher = request.getRequestDispatcher("/WEB-INF/JSP/QandAEdit.jsp");
-		dispatcher.forward(request, response);
+		// 編集画面に直接アクセスされた際は、質問一覧画面に強制リダイレクトさせる
+		response.sendRedirect("/QandASystem/list");
 	}
 
 	/**
@@ -47,19 +47,21 @@ public class edit extends HttpServlet {
 		int questionId = Integer.parseInt(request.getParameter("question_id"));
 		String editDeleteKey = request.getParameter("edit-delete-key");
 
+		// 「編集・削除キー」がNULLではない場合に限り、DBへの問い合わせを行う
 		if (questionId > 0 && editDeleteKey != "") {
 			VerifyKeyGetQuestionLogic VerifyKeyGetQuestionLogic = new VerifyKeyGetQuestionLogic();
 			try {
+				// POSTされたquestionIdをキーに質問情報を取得する
 				Question question = VerifyKeyGetQuestionLogic.execute(questionId);
+				// 取得した質問情報から「編集・削除キー」を変数に格納する
 				String verifyKey = question.getEditDeleteKey();
-
+				// POSTされた「編集・削除キー」がDBの値と一致した場合は、取得した質問情報をJSPに渡し、編集画面に遷移する
 				if (editDeleteKey.equals(verifyKey)) {
 					request.setAttribute("question", question);
 					RequestDispatcher dispatcher = request.getRequestDispatcher("/WEB-INF/JSP/QandAEdit.jsp");
-
-					System.out.println(question);
 					dispatcher.forward(request, response);
 				} else {
+					// 入力された「編集・削除キー」と、DBの値が一致しない場合は、errorIdを設定し、元の画面にリダイレクト
 					response.sendRedirect("/QandASystem/confirm?questionId=" + questionId + "&errorId=" + 1);
 				}
 			} catch (Exception e) {
@@ -69,6 +71,7 @@ public class edit extends HttpServlet {
 				return;
 			}
 		} else {
+			// 「編集・削除キー」を未入力でPOSTした際は、DBへの問い合わせを行わず、質問確認画面へリダイレクトさせる
 			response.sendRedirect("/QandASystem/confirm?questionId=" + questionId + "&errorId=" + 2);
 		}
 	}

--- a/src/editComplete.java
+++ b/src/editComplete.java
@@ -1,6 +1,7 @@
 
 
 import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
 import java.sql.SQLException;
 
 import javax.servlet.RequestDispatcher;
@@ -12,6 +13,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import model.Question;
 import model.UpdateQuestionLogic;
+import sandbox.Hashing;
 
 /**
  * Servlet implementation class editComplete
@@ -55,6 +57,15 @@ public class editComplete extends HttpServlet {
 		String EditDeleteKey = request.getParameter("edit-delete-key");
 
 		if (questionerName != "" && questionTitle != "" && questionContent != "" && questionUrgency != 0 && EditDeleteKey != "") {
+			try {
+				Hashing Hashing = new Hashing();
+				EditDeleteKey = Hashing.hash(EditDeleteKey);
+			} catch (NoSuchAlgorithmException e) {
+				e.printStackTrace();
+				RequestDispatcher dispatcher = request.getRequestDispatcher("/WEB-INF/JSP/QandAError.jsp");
+				dispatcher.forward(request, response);
+	    	return;
+			}
 			Question question = new Question(questionId, questionerName, questionTitle, questionContent, questionUrgency, EditDeleteKey);
 			UpdateQuestionLogic UpdateQuestionLogic = new UpdateQuestionLogic();
 			try {
@@ -73,6 +84,7 @@ public class editComplete extends HttpServlet {
 			request.setAttribute("errorMsg", "必須項目のいずれか（名前/タイトル/内容/緊急度）が未入力/未選択です。");
 			Question question = new Question(questionId, questionerName, questionTitle, questionContent, questionUrgency, EditDeleteKey);
 			request.setAttribute("question", question);
+			request.setAttribute("errorMsg", "更新できませんでした。全項目入力の上、再度更新ボタンを押してください。");
 			// response.sendRedirect("/QandASystem/edit");
 			RequestDispatcher dispatcher = request.getRequestDispatcher("/WEB-INF/JSP/QandAEdit.jsp");
 			dispatcher.forward(request, response);

--- a/src/editComplete.java
+++ b/src/editComplete.java
@@ -1,11 +1,17 @@
 
 
 import java.io.IOException;
+import java.sql.SQLException;
+
+import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import model.Question;
+import model.UpdateQuestionLogic;
 
 /**
  * Servlet implementation class editComplete
@@ -13,7 +19,7 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/editComplete")
 public class editComplete extends HttpServlet {
 	private static final long serialVersionUID = 1L;
-       
+
     /**
      * @see HttpServlet#HttpServlet()
      */
@@ -34,8 +40,42 @@ public class editComplete extends HttpServlet {
 	 * @see HttpServlet#doPost(HttpServletRequest request, HttpServletResponse response)
 	 */
 	protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-		// TODO Auto-generated method stub
-		doGet(request, response);
-	}
+		// リクエストパラメータの取得
+		request.setCharacterEncoding("UTF-8");
 
+		int questionId = Integer.parseInt(request.getParameter("questionId"));
+		String questionerName = request.getParameter("questioner-name");
+		String questionTitle = request.getParameter("question-title");
+		String questionContent = request.getParameter("question-content");
+		// 緊急度はデフォルトで0をセットする
+		int questionUrgency = 0;
+		if (request.getParameter("urgency") != null) {
+			questionUrgency = Integer.parseInt(request.getParameter("urgency"));
+		}
+		String EditDeleteKey = request.getParameter("edit-delete-key");
+
+		if (questionerName != "" && questionTitle != "" && questionContent != "" && questionUrgency != 0 && EditDeleteKey != "") {
+			Question question = new Question(questionId, questionerName, questionTitle, questionContent, questionUrgency, EditDeleteKey);
+			UpdateQuestionLogic UpdateQuestionLogic = new UpdateQuestionLogic();
+			try {
+				UpdateQuestionLogic.update(question);
+			} catch (SQLException | ClassNotFoundException e) {
+				RequestDispatcher dispatcher = request.getRequestDispatcher("/WEB-INF/JSP/QandAError.jsp");
+				dispatcher.forward(request, response);
+				return;
+			} catch (Exception e) {
+				RequestDispatcher dispatcher = request.getRequestDispatcher("/WEB-INF/JSP/QandAError.jsp");
+				dispatcher.forward(request, response);
+			}
+			response.sendRedirect("/QandASystem/confirm?questionId=" + questionId);
+		} else {
+			// 必須項目一つでも未入力の場合は、エラーメッセージを定義の上、質問登録画面にフォワードする。
+			request.setAttribute("errorMsg", "必須項目のいずれか（名前/タイトル/内容/緊急度）が未入力/未選択です。");
+			Question question = new Question(questionId, questionerName, questionTitle, questionContent, questionUrgency, EditDeleteKey);
+			request.setAttribute("question", question);
+			// response.sendRedirect("/QandASystem/edit");
+			RequestDispatcher dispatcher = request.getRequestDispatcher("/WEB-INF/JSP/QandAEdit.jsp");
+			dispatcher.forward(request, response);
+		}
+	}
 }

--- a/src/model/UpdateQuestionLogic.java
+++ b/src/model/UpdateQuestionLogic.java
@@ -1,0 +1,16 @@
+package model;
+
+import java.sql.SQLException;
+
+import dao.QuestionsDAO;
+
+/**
+ * UpdateQuestionLogicは、QuestionsDAOで定義されたupdateメソッドを利用して、質問更新処理を行います。
+ */
+
+public class UpdateQuestionLogic  {
+	public void update (Question question) throws SQLException, ClassNotFoundException {
+		QuestionsDAO dao = new QuestionsDAO();
+		dao.update(question);
+	}
+}

--- a/src/model/VerifyKeyGetQuestionLogic.java
+++ b/src/model/VerifyKeyGetQuestionLogic.java
@@ -1,0 +1,14 @@
+package model;
+
+import java.sql.SQLException;
+
+import dao.QuestionsDAO;
+
+public class VerifyKeyGetQuestionLogic {
+	public Question execute(int questionId) throws SQLException, ClassNotFoundException {
+		Question question = new Question();
+		QuestionsDAO dao = new QuestionsDAO();
+		question = dao.questionEdit(questionId);
+		return question;
+	}
+}

--- a/src/regist.java
+++ b/src/regist.java
@@ -1,5 +1,6 @@
 
 import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
 
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletException;
@@ -10,6 +11,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import model.PostQuestionLogic;
 import model.Question;
+import sandbox.Hashing;
 
 /**
  * registは、/registにアクセスされた際の処理を定義するサーブレットクラスです。
@@ -52,6 +54,18 @@ public class regist extends HttpServlet {
 		String EditDeleteKey = request.getParameter("register-cancel-key");
 
 		if (questionerName != "" && questionTitle != "" && questionContent != "" && questionUrgency != 0 ) {
+			// 編集・削除キーが空でなければ、キーのハッシュ化を行う
+			if (EditDeleteKey != "") {
+				try {
+					Hashing Hashing = new Hashing();
+					EditDeleteKey = Hashing.hash(EditDeleteKey);
+				} catch (NoSuchAlgorithmException e) {
+					e.printStackTrace();
+					RequestDispatcher dispatcher = request.getRequestDispatcher("/WEB-INF/JSP/QandAError.jsp");
+					dispatcher.forward(request, response);
+		    	return;
+				}
+			}
 			Question question = new Question(questionerName, questionTitle, questionContent, questionUrgency, EditDeleteKey);
 			PostQuestionLogic postQuestionLogic = new PostQuestionLogic();
 			postQuestionLogic.execute(question);

--- a/src/sandbox/Hashing.java
+++ b/src/sandbox/Hashing.java
@@ -1,0 +1,20 @@
+package sandbox;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import javax.xml.bind.DatatypeConverter;
+
+/**
+ * Hashingは、SHA-256アルゴリズムを用いて、キーをハッシュ化するクラスです。
+ * @param password 編集・削除キー入力値
+ * */
+
+public class Hashing {
+    public String hash(String password) throws NoSuchAlgorithmException {
+        MessageDigest messageDigest = MessageDigest.getInstance("SHA-256"); //SHA-256のアルゴリズムを用いて、ハッシュ化を行う
+        byte[] b = password.getBytes(); //ハッシュ化する文字列をバイト配列に変換する
+        String hashedPassword = DatatypeConverter.printHexBinary(messageDigest.digest(b)); //Stringに再変換してreturnする
+        return hashedPassword;
+    }
+}


### PR DESCRIPTION
下記の通り、実装致しました。
- /editへの「GET」メソッドでの直接アクセスを禁止。
- 「編集・削除キー」は、ハッシュ化してDBに保管する仕様に変更。
- POSTされたキーのハッシュ値がDBの値と一致しない場合は、errorId「１」で、/confirmにリダイレクトする。
- POSTされた値が空の場合は、errorId「２」で、/confirmにリダイレクトする。
- /editCompleteにフォームをPOSTした際、いずれかのパラメータ（編集・削除キーを含む）が空だった場合は、/editにフォワードさせる。